### PR TITLE
GH-2 Fix deploy workflow

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -31,7 +31,6 @@ jobs:
       - name: "Release"
         uses: helm/chart-releaser-action@v1.4.1
         with:
-          charts_dir: charts/*
           charts_repo_url: https://helm.reposilite.com
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request attempts to fix an issue with the deploy workflow preventing the charts from being deployed to GitHub Actions.
