### PR TITLE
Add configurable ServiceAccount token

### DIFF
--- a/charts/reposilite/templates/serviceaccount.yaml
+++ b/charts/reposilite/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/reposilite/values.yaml
+++ b/charts/reposilite/values.yaml
@@ -187,6 +187,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  automountServiceAccountToken: false
 
 ## Pod affinity
 affinity: {}


### PR DESCRIPTION
From an application perspective, there is no need to mount a Kubernetes API token into the running container. Mounting it is default behavior of any ServiceAccount that does not set `automountServiceAccountToken` to false.

This change allows to configure that mounting behavior. The Helm Chart by default disables it.

Resolves first list entry of #9 