### PR TITLE
Support configurable security context

### DIFF
--- a/charts/reposilite/templates/_podtemplate.tpl
+++ b/charts/reposilite/templates/_podtemplate.tpl
@@ -16,6 +16,9 @@
       {{- end }}
       serviceAccountName: {{ include "reposilite.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ default 60 .Values.deployment.terminationGracePeriodSeconds }}
+      {{- if .Values.deployment.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.deployment.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.deployment.initContainers }}
       initContainers:
         {{- toYaml . | nindent 6 }}
@@ -62,6 +65,9 @@
         {{- with .Values.envFrom }}
         envFrom:
           {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.deployment.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.deployment.containerSecurityContext "enabled" | toYaml | nindent 10 }}
         {{- end }}
       {{- if .Values.deployment.additionalContainers }}
         {{- toYaml .Values.deployment.additionalContainers | nindent 6 }}

--- a/charts/reposilite/values.yaml
+++ b/charts/reposilite/values.yaml
@@ -57,9 +57,11 @@ deployment:
     #     port: 8080
     #     host: localhost
     #     scheme: http
+  # Security context for all initContainers and containers in the pod
   podSecurityContext:
     enabled: false
     fsGroup: 999
+  # Security context specific to the runtime container in the pod.
   containerSecurityContext:
     enabled: false
     runAsUser: 999

--- a/charts/reposilite/values.yaml
+++ b/charts/reposilite/values.yaml
@@ -57,6 +57,14 @@ deployment:
     #     port: 8080
     #     host: localhost
     #     scheme: http
+  podSecurityContext:
+    enabled: false
+    fsGroup: 999
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 999
+    runAsGroup: 999
+
 
 ## Service configuration
 service:


### PR DESCRIPTION
Deploying this Helm Chart may require running the application as non-root, with as few capabilities as possible.

With the possibility to configure the a `securityContext` on both pod-level and container-level, such requirements can be easier satisfied.

For backwards compatibility, both security context specifications are disabled by default.

Resolves second list entry of #9.