### PR TITLE
Support mounting additional volumes into application container

### DIFF
--- a/charts/reposilite/templates/_podtemplate.tpl
+++ b/charts/reposilite/templates/_podtemplate.tpl
@@ -55,6 +55,9 @@
             {{- if .Values.persistence.subPath }}
             subPath: {{ .Values.persistence.subPath }}
             {{- end }}
+          {{- if .Values.deployment.additionalVolumeMounts }}
+          {{- toYaml .Values.deployment.additionalVolumeMounts | nindent 10 }}
+          {{- end }}
         {{- with .Values.env }}
         env:
           {{- toYaml . | nindent 10 }}

--- a/charts/reposilite/values.yaml
+++ b/charts/reposilite/values.yaml
@@ -40,11 +40,17 @@ deployment:
     #   volumeMounts:
     #     - name: volume-name
     #       mountPath: /data
-  # Additional volumes for use with initContainers and additionalContainers
+  # Additional volumes for use with initContainers, additionalContainers and runtime container itself
   additionalVolumes: []
     # - name: name
     #   hostPath:
     #     path: /tmp
+    # - name: logging
+    #   emptyDir: {}
+  # Additional mount points for the runtime container. Refer to volumes defined in `additionalVolumes`.
+  additionalVolumeMounts: []
+    # - name: logging
+    #   mountPath: /var/log/reposilite/
   # Image pull secrets
   imagePullSecrets: []
   lifecycle: {}


### PR DESCRIPTION
Right now, `additionalVolumes` can only be used for `initContainers` and `additionalContainers`. There is no way to mount additional volumes into the application container itself.

This change introduces a new value `additionalVolumeMounts` which will be added to the application containers' `volumeMounts` on templating. A common use case is to mount Kubernetes ConfigMaps or Secrets into the container.

By default, no additional mount points are defined.

Resolves third list entry of #9.