### PR TITLE
Define reposilite.podAnnotations to allow dynamic annotations

### DIFF
--- a/charts/reposilite/templates/_helpers.tpl
+++ b/charts/reposilite/templates/_helpers.tpl
@@ -43,6 +43,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Common annotations. Overwrite to add custom annotations.
+*/}}
+{{- define "reposilite.podAnnotations" -}}{{- end -}}
+
+{{/*
 Selector labels
 */}}
 {{- define "reposilite.selectorLabels" -}}

--- a/charts/reposilite/templates/_podtemplate.tpl
+++ b/charts/reposilite/templates/_podtemplate.tpl
@@ -1,6 +1,7 @@
 {{- define "reposilite.podTemplate" }}
     metadata:
       annotations:
+      {{- include "reposilite.podAnnotations" . | nindent 8 -}}
       {{- with .Values.deployment.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
When configuring reposilite via helm values, I would like to be able to have the pod be automatically recreated when values change.

This is usually done by a checksum annotation which computes a hash of your values.

Adding this extension point would allow users of the chart to specify their own checksum annotations.