### PR TITLE
GH-21 Add namespace to manifests in templates

### DIFF
--- a/charts/reposilite/templates/deployment.yaml
+++ b/charts/reposilite/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "reposilite.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- with .Values.deployment.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/reposilite/templates/hpa.yaml
+++ b/charts/reposilite/templates/hpa.yaml
@@ -11,6 +11,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "reposilite.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reposilite.labels" . | nindent 4 }}
 spec:

--- a/charts/reposilite/templates/ingress.yaml
+++ b/charts/reposilite/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reposilite.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/reposilite/templates/pvc.yaml
+++ b/charts/reposilite/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "reposilite.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- with .Values.persistence.annotations  }}
     {{ toYaml . | nindent 4 }}

--- a/charts/reposilite/templates/service.yaml
+++ b/charts/reposilite/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "reposilite.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- with .Values.service.annotations  }}
     {{ toYaml . | nindent 4 }}

--- a/charts/reposilite/templates/serviceaccount.yaml
+++ b/charts/reposilite/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "reposilite.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "reposilite.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
### Description
- ArgoCD v3.3 has updated to [kustomize v5.8.0](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/3.2-3.3/#kustomize-upgraded-to-580)
- kustomize v5.8.0 has changed the way kustomize handles helmCharts: https://github.com/kubernetes-sigs/kustomize/pull/5940 which has a nice tl;dr:

```
TL;DR

If you use Kustomize with Helm charts, ensure that your Helm templates explicitly set the namespace, for example:

metadata:
  namespace: {{ .Release.Namespace }}

If your charts already handle namespaces this way, this change should not introduce any breaking behavior.
```
None of resources in the Reposilite helm chart include this namepace and rendering them using kustomize >= 5.8.0 leaves those resources w/o namespace
