### PR TITLE
Add service.trafficDistribution for topology-aware routing

### DIFF
--- a/charts/reposilite/Chart.yaml
+++ b/charts/reposilite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: reposilite
-version: "1.3.28" # The version of this chart.
+version: "1.3.29" # The version of this chart.
 appVersion: "3.5.28" # The latest version of Reposilite.
 description: "Lightweight and easy-to-use repository management software dedicated for the Maven based artifacts in the JVM ecosystem"
 icon: https://raw.githubusercontent.com/dzikoysk/reposilite/main/reposilite-site/public/images/favicon.png

--- a/charts/reposilite/templates/service.yaml
+++ b/charts/reposilite/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- include "reposilite.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/reposilite/values.yaml
+++ b/charts/reposilite/values.yaml
@@ -79,6 +79,8 @@ service:
   type: ClusterIP
   port: 8080
   annotations: {}
+  # Topology-aware routing, e.g. "PreferSameZone" (k8s 1.33+). https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+  trafficDistribution: ""
 
 ## HorizontalPodAutoscaler configuration.
 autoscaling:


### PR DESCRIPTION
Adds a `service.trafficDistribution` value, templated into `spec.trafficDistribution` on the Service when set.

`spec.trafficDistribution` is a [k8s 1.31+ GA field](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) that lets operators prefer topologically closer endpoints — helpful in multi-AZ clusters to optimize for performance, cost, or reliability (k8s docs' own framing). `PreferSameZone` is the current value name (`PreferClose` is the deprecated alias).

Backwards compatible: default is `""` (matching `image.tag`, `nameOverride`, etc.), and the `{{- with }}` guard skips the field entirely — rendered output is byte-identical to 1.3.28 for users who don't set it.

Chart version bumped 1.3.28 → 1.3.29.